### PR TITLE
Feature/deploy to gcp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GCP
+
+on:
+  release:
+    types: [published]
+  workflow_run:
+    workflows: ["Publish Docker image"]
+    types:
+      - completed
+  workflow_dispatch:
+
+env:
+  REGISTRY: 59vkckvlkjdfglkjdfv
+  IMAGE_NAME: mandelbrot-tinker
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.5.7
+
+      - name: Initialize Terraform
+        working-directory: ./deployment/gcp
+        run: terraform init
+
+      - name: Apply Terraform
+        working-directory: ./deployment/gcp
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+        run: terraform apply -auto-approve -var="image_tag=${{ github.event.release.tag_name }}"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Toy challenge to learn Go.
 
 ## How to Use
 
+### GCP
+See it running on GCP at:
+[https://mandelbrot-629070084289.europe-west2.run.app/](https://mandelbrot-629070084289.europe-west2.run.app/)
+
 ### Run from a Docker Container
 To run the application from a Docker container, use the following command:
 ```sh

--- a/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
+++ b/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "mandelbrot" {
 
   template {
     containers {
-      image = "59vkckvlkjdfglkjdfv/mandelbrot-tinker:0.0.7"
+      image = "59vkckvlkjdfglkjdfv/mandelbrot-tinker:${var.mandelbrot_version}"
       resources {
         limits = {
           cpu    = "2"

--- a/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
+++ b/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
@@ -7,11 +7,11 @@ resource "google_cloud_run_v2_service" "mandelbrot" {
 
   template {
     containers {
-      image = "59vkckvlkjdfglkjdfv/mandelbrot-tinker:0.0.6"
+      image = "59vkckvlkjdfglkjdfv/mandelbrot-tinker:0.0.7"
       resources {
         limits = {
           cpu    = "2"
-          memory = "8096Mi"
+          memory = "8192Mi"
         }
       }
       startup_probe {

--- a/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
+++ b/deployment/gcp/cloud_run_v2_service_mandelbrot.tf
@@ -1,3 +1,4 @@
+// Create a Cloud Run service
 resource "google_cloud_run_v2_service" "mandelbrot" {
   name     = "mandelbrot"
   location = "europe-west2" // London
@@ -32,6 +33,7 @@ resource "google_cloud_run_v2_service" "mandelbrot" {
   }
 }
 
+// Allow all users to invoke the service
 resource "google_cloud_run_service_iam_binding" "mandelbrot" {
   project = "mandelbrot-tinker"
   location = google_cloud_run_v2_service.mandelbrot.location

--- a/deployment/gcp/main.tf
+++ b/deployment/gcp/main.tf
@@ -1,0 +1,6 @@
+terraform {
+    backend "gcs" {
+        bucket  = "mandelbrot-tinker-terraform"
+        prefix  = "terraform/state"
+    }
+}

--- a/deployment/gcp/variables.tf
+++ b/deployment/gcp/variables.tf
@@ -1,0 +1,4 @@
+variable "mandelbrot_version" {
+    description = "The version of the Mandelbrot service"
+    type        = string
+}

--- a/main_test.go
+++ b/main_test.go
@@ -90,3 +90,41 @@ func TestLivez(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %q want %q", rr.Body.String(), expected)
 	}
 }
+
+func TestMandelbrotGoodValues(t *testing.T) {
+	req, err := http.NewRequest("GET", "/mandelbrot?xmin=-2&ymin=-2&xmax=2&ymax=2&width=800&height=800", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate the mandelbrot handler
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+func TestMandelbrotOddValues(t *testing.T) {
+	req, err := http.NewRequest("GET", "/mandelbrot?xmin=-1000&ymin=-1000&xmax=1000&ymax=1000&width=10000&height=10000", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate the mandelbrot handler
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -30,30 +30,31 @@ func webserver(port int) {
 		if err != nil {
 			xminF = -2.0
 		}
-		if xminF == 0 {
-			xminF = -2.0
-		}
+		xminF = clipToRange(xminF, -2.0, 2.0)
 
 		yminF, _ := strconv.ParseFloat(params.Get("ymin"), 64)
-		if yminF == 0 {
-			yminF = -2.0
-		}
+		yminF = clipToRange(yminF, -2.0, 2.0)
 
 		xmaxF, _ := strconv.ParseFloat(params.Get("xmax"), 64)
 		if xmaxF == 0 {
 			xmaxF = 2.0
 		}
+		xmaxF = clipToRange(xmaxF, -2.0, 2.0)
 
 		ymaxF, _ := strconv.ParseFloat(params.Get("ymax"), 64)
 		if ymaxF == 0 {
 			ymaxF = 2.0
 		}
+		ymaxF = clipToRange(ymaxF, -2.0, 2.0)
 
 		widthI, err := strconv.Atoi(params.Get("width"))
 		if err != nil {
 			widthI = 800
 		}
+		widthI = clipToRangeInt(widthI, 128, 1024)
+
 		heightI, _ := strconv.Atoi(params.Get("height"))
+		heightI = clipToRangeInt(heightI, 128, 1024)
 
 		img, err := processInput(xminF, yminF, xmaxF, ymaxF, widthI, heightI)
 		if err != nil {
@@ -87,4 +88,24 @@ func webserver(port int) {
 	if err != nil {
 		log.Fatalf("could not start server: %s\n", err)
 	}
+}
+
+func clipToRange(xminF, f1, f2 float64) float64 {
+	if xminF < f1 {
+		return f1
+	}
+	if xminF > f2 {
+		return f2
+	}
+	return xminF
+}
+
+func clipToRangeInt(xminI, f1, f2 int) int {
+	if xminI < f1 {
+		return f1
+	}
+	if xminI > f2 {
+		return f2
+	}
+	return xminI
 }

--- a/static/index.html
+++ b/static/index.html
@@ -16,11 +16,11 @@
             <div class="form-row">
                 <div class="form-group col-md-2">
                     <label for="width">Width</label>
-                    <input type="number" class="form-control" name="width" id="width" placeholder="Width" value="1024" required>
+                    <input type="number" class="form-control" name="width" id="width" placeholder="Width" value="512" min="128" max="1024" step="128" required>
                 </div>
                 <div class="form-group col-md-2">
                     <label for="height">Height</label>
-                    <input type="number" class="form-control" name="height" id="height" placeholder="Height" value="1024" required>
+                    <input type="number" class="form-control" name="height" id="height" placeholder="Height" value="512" min="128" max="1024" step="128" required>
                 </div>
                 <div class="form-group col-md-2">
                     <label for="xmin">X Min</label>


### PR DESCRIPTION
This pull request includes several changes to deploy the Mandelbrot service to Google Cloud Platform (GCP), update the Terraform configuration, add new tests, and improve input validation in the web server. The most important changes are summarized below:

### Deployment to GCP:

* Added a GitHub Actions workflow (`.github/workflows/deploy.yml`) to deploy the service to GCP on release and workflow dispatch.

### Terraform Configuration:

* Updated the Terraform configuration to use a GCS backend for storing the Terraform state (`deployment/gcp/main.tf`).
* Added a new variable for the Mandelbrot service version (`deployment/gcp/variables.tf`).
* Modified the Cloud Run service to use the version variable and increased memory limits (`deployment/gcp/cloud_run_v2_service_mandelbrot.tf`). [[1]](diffhunk://#diff-248d770ab9bdb6a00bcd6bb79371c4f215f2ea63c89652eb44fc6930166832efL10-R15) [[2]](diffhunk://#diff-248d770ab9bdb6a00bcd6bb79371c4f215f2ea63c89652eb44fc6930166832efR1)

### Application Changes:

* Added input validation functions `clipToRange` and `clipToRangeInt` to the web server to ensure input values are within specified ranges (`server.go`). [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L33-R57) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R92-R111)
* Updated the HTML form to include input validation for width and height (`static/index.html`).

### Tests:

* Added new tests for the Mandelbrot endpoint with different input values (`main_test.go`).

### Documentation:

* Updated the `README.md` to include a link to the running service on GCP.